### PR TITLE
kafka message currupt ignore

### DIFF
--- a/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
@@ -201,7 +201,7 @@ public class KafkaSpout implements IRichSpout {
                 size++;
             }
         }
-        catch (final ConsumerTimeoutException e) {
+        catch (final Exception e) {
             // ignore, storm will call nextTuple again at some point in the near future
             // timeout does *not* mean that no messages were read (state is checked below)
         }

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
@@ -32,6 +32,7 @@ import java.util.Queue;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import kafka.message.InvalidMessageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,6 +201,9 @@ public class KafkaSpout implements IRichSpout {
                 _inProgress.put(id, message.message());
                 size++;
             }
+        }
+        catch (final InvalidMessageException e) {
+            LOG.warn(e.getMessage(), e);
         }
         catch (final Exception e) {
             // ignore, storm will call nextTuple again at some point in the near future

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
@@ -205,7 +205,7 @@ public class KafkaSpout implements IRichSpout {
         catch (final InvalidMessageException e) {
             LOG.warn(e.getMessage(), e);
         }
-        catch (final Exception e) {
+        catch (final ConsumerTimeoutException e) {
             // ignore, storm will call nextTuple again at some point in the near future
             // timeout does *not* mean that no messages were read (state is checked below)
         }


### PR DESCRIPTION
2015-05-08T08:33:54.741+0900 b.s.util [ERROR] Async loop died!
kafka.message.InvalidMessageException: Message is corrupt (stored crc = 2940171851, computed crc = 1298293347)
    at kafka.message.Message.ensureValid(Message.scala:166) ~[stormjar.jar:na]
    at kafka.consumer.ConsumerIterator.makeNext(ConsumerIterator.scala:101) ~[stormjar.jar:na]
    at kafka.consumer.ConsumerIterator.makeNext(ConsumerIterator.scala:33) ~[stormjar.jar:na]
    at kafka.utils.IteratorTemplate.maybeComputeNext(IteratorTemplate.scala:66) ~[stormjar.jar:na]
    at kafka.utils.IteratorTemplate.hasNext(IteratorTemplate.scala:58) ~[stormjar.jar:na]
    at nl.minvenj.nfi.storm.kafka.KafkaSpout.fillBuffer(KafkaSpout.java:197) ~[stormjar.jar:na]
    at nl.minvenj.nfi.storm.kafka.KafkaSpout.nextTuple(KafkaSpout.java:286) ~[stormjar.jar:na]
    at com.daumcorp.explorer.pipe.common.KafkaSpoutOnElasticClusterHealth.nextTuple(KafkaSpoutOnElasticClusterHealth.java:67) ~[stormjar.jar:na]
    at backtype.storm.daemon.executor$fn__4445$fn__4460$fn__4489.invoke(executor.clj:565) ~[storm-core-0.9.4-SNAPSHOT.jar:0.9.4-SNAPSHOT]
    at backtype.storm.util$async_loop$fn__558.invoke(util.clj:463) ~[storm-core-0.9.4-SNAPSHOT.jar:0.9.4-SNAPSHOT]
    at clojure.lang.AFn.run(AFn.java:24) [clojure-1.5.1.jar:na]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_31]
2015-05-08T08:33:54.741+0900 b.s.d.executor [ERROR]
kafka.message.InvalidMessageException: Message is corrupt (stored crc = 2940171851, computed crc = 1298293347)
    at kafka.message.Message.ensureValid(Message.scala:166) ~[stormjar.jar:na]
    at kafka.consumer.ConsumerIterator.makeNext(ConsumerIterator.scala:101) ~[stormjar.jar:na]
    at kafka.consumer.ConsumerIterator.makeNext(ConsumerIterator.scala:33) ~[stormjar.jar:na]
    at kafka.utils.IteratorTemplate.maybeComputeNext(IteratorTemplate.scala:66) ~[stormjar.jar:na]
    at kafka.utils.IteratorTemplate.hasNext(IteratorTemplate.scala:58) ~[stormjar.jar:na]
    at nl.minvenj.nfi.storm.kafka.KafkaSpout.fillBuffer(KafkaSpout.java:197) ~[stormjar.jar:na]
    at nl.minvenj.nfi.storm.kafka.KafkaSpout.nextTuple(KafkaSpout.java:286) ~[stormjar.jar:na]
    at com.daumcorp.explorer.pipe.common.KafkaSpoutOnElasticClusterHealth.nextTuple(KafkaSpoutOnElasticClusterHealth.java:67) ~[stormjar.jar:na]
    at backtype.storm.daemon.executor$fn__4445$fn__4460$fn__4489.invoke(executor.clj:565) ~[storm-core-0.9.4-SNAPSHOT.jar:0.9.4-SNAPSHOT]
    at backtype.storm.util$async_loop$fn__558.invoke(util.clj:463) ~[storm-core-0.9.4-SNAPSHOT.jar:0.9.4-SNAPSHOT]
    at clojure.lang.AFn.run(AFn.java:24) [clojure-1.5.1.jar:na]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_31]
2015-05-08T08:33:54.841+0900 b.s.util [ERROR] Halting process: ("Worker died")
java.lang.RuntimeException: ("Worker died")