### PR TITLE
Update storm dep to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 
 jdk:
-    - openjdk6
-    - openjdk7
     - oraclejdk7
     - oraclejdk8
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <mockito.version>1.10.19</mockito.version>
         <slf4j.version>1.7.12</slf4j.version>
         <source.plugin.version>2.4</source.plugin.version>
-        <storm.version>0.9.5</storm.version>
+        <storm.version>1.0.0</storm.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/KafkaSpout.java
@@ -16,6 +16,8 @@
 
 package nl.minvenj.nfi.storm.kafka;
 
+import static java.nio.ByteBuffer.wrap;
+
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.CONFIG_FAIL_HANDLER;
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.DEFAULT_FAIL_HANDLER;
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.createFailHandlerFromString;
@@ -32,22 +34,22 @@ import java.util.Queue;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import kafka.message.InvalidMessageException;
+import org.apache.storm.spout.RawScheme;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.IRichSpout;
+import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.spout.RawScheme;
-import backtype.storm.spout.Scheme;
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichSpout;
-import backtype.storm.topology.OutputFieldsDeclarer;
 import kafka.consumer.Consumer;
 import kafka.consumer.ConsumerConfig;
 import kafka.consumer.ConsumerIterator;
 import kafka.consumer.ConsumerTimeoutException;
 import kafka.consumer.KafkaStream;
 import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.InvalidMessageException;
 import kafka.message.MessageAndMetadata;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.util.ConfigUtils;
@@ -296,7 +298,7 @@ public class KafkaSpout implements IRichSpout {
                     throw new IllegalStateException("no pending message for next id " + nextId);
                 }
                 // use specified scheme to deserialize messages (single-field Values by default)
-                _collector.emit(_serializationScheme.deserialize(message), nextId);
+                _collector.emit(_serializationScheme.deserialize(wrap(message)), nextId);
                 LOG.debug("emitted kafka message id {} ({} bytes payload)", nextId, message.length);
             }
         }

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/fail/AbstractFailHandler.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/fail/AbstractFailHandler.java
@@ -18,8 +18,8 @@ package nl.minvenj.nfi.storm.kafka.fail;
 
 import java.util.Map;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/fail/AbstractFailHandler.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/fail/AbstractFailHandler.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
+
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/fail/FailHandler.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/fail/FailHandler.java
@@ -19,8 +19,8 @@ package nl.minvenj.nfi.storm.kafka.fail;
 import java.io.Serializable;
 import java.util.Map;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**
@@ -63,15 +63,15 @@ public interface FailHandler extends Serializable {
 
     /**
      * Called by the {@link nl.minvenj.nfi.storm.kafka.KafkaSpout} when
-     * {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, backtype.storm.task.TopologyContext, backtype.storm.spout.SpoutOutputCollector)}
+     * {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, org.apache.storm.task.TopologyContext, org.apache.storm.spout.SpoutOutputCollector)}
      * is called on it to allow the {@link FailHandler} to update its state.
      *
      * @param config    The configuration as passed to
-     *                  {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, backtype.storm.task.TopologyContext, backtype.storm.spout.SpoutOutputCollector)}.
+     *                  {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, org.apache.storm.task.TopologyContext, org.apache.storm.spout.SpoutOutputCollector)}.
      * @param topology  The {@link TopologyContext} as passed to
-     *                  {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, backtype.storm.task.TopologyContext, backtype.storm.spout.SpoutOutputCollector)}.
+     *                  {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, org.apache.storm.task.TopologyContext, org.apache.storm.spout.SpoutOutputCollector)}.
      * @param collector The {@link SpoutOutputCollector} as passed to
-     *                  {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, backtype.storm.task.TopologyContext, backtype.storm.spout.SpoutOutputCollector)}.
+     *                  {@link nl.minvenj.nfi.storm.kafka.KafkaSpout#open(java.util.Map, org.apache.storm.task.TopologyContext, org.apache.storm.spout.SpoutOutputCollector)}.
      */
     void open(Map config, TopologyContext topology, SpoutOutputCollector collector);
 

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/fail/FailHandler.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/fail/FailHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
+
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/fail/ReliableFailHandler.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/fail/ReliableFailHandler.java
@@ -20,7 +20,7 @@ import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**
  * {@link FailHandler} implementation making tuple failure reliable: messages are always replayed, calls to
- * {@link #fail(nl.minvenj.nfi.storm.kafka.util.KafkaMessageId, byte[])} will cause an error.
+ * {@link #fail(KafkaMessageId, byte[])} will cause an error.
  *
  * @author Netherlands Forensics Institute
  */

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/fail/UnreliableFailHandler.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/fail/UnreliableFailHandler.java
@@ -20,7 +20,7 @@ import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**
  * {@link FailHandler} implementation making tuple failure unreliable: messages are never replayed and calls to
- * {@link #fail(nl.minvenj.nfi.storm.kafka.util.KafkaMessageId, byte[])} are ignored.
+ * {@link #fail(KafkaMessageId, byte[])} are ignored.
  *
  * @author Netherlands Forensics Institute
  */

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtils.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtils.java
@@ -26,7 +26,7 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.Config;
+import org.apache.storm.Config;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.ReliableFailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.UnreliableFailHandler;
@@ -186,8 +186,8 @@ public class ConfigUtils {
 
     /**
      * Creates a zookeeper connect string usable for the kafka configuration property {@code "zookeeper.connect"} from
-     * storm's configuration map by looking up the {@link backtype.storm.Config#STORM_ZOOKEEPER_SERVERS} and
-     * {@link backtype.storm.Config#STORM_ZOOKEEPER_PORT} values. Returns null when this procedure fails.
+     * storm's configuration map by looking up the {@link org.apache.storm.Config#STORM_ZOOKEEPER_SERVERS} and
+     * {@link org.apache.storm.Config#STORM_ZOOKEEPER_PORT} values. Returns null when this procedure fails.
      *
      * @param stormConfig Storm's configuration map.
      * @return A zookeeper connect string if it can be created from storm's config or null.

--- a/src/main/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtils.java
+++ b/src/main/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtils.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.storm.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.storm.Config;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.ReliableFailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.UnreliableFailHandler;

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutConstructorTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutConstructorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -16,11 +17,11 @@ import java.util.Map;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 
-import backtype.storm.spout.Scheme;
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.tuple.Fields;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
 import nl.minvenj.nfi.storm.kafka.util.ConfigUtils;
 
 public class KafkaSpoutConstructorTest {
@@ -118,10 +119,13 @@ public class KafkaSpoutConstructorTest {
     public void testDelegateCustomScheme() {
         final Scheme scheme = new Scheme() {
             @Override
-            public List<Object> deserialize(final byte[] bytes) {
+            public List<Object> deserialize(final ByteBuffer bytes) {
+                final byte[] result = new byte[bytes.limit() - 1];
+                bytes.get(result, 1, bytes.limit());
+
                 return Arrays.<Object>asList(
-                    new byte[]{bytes[0]},
-                    Arrays.copyOfRange(bytes, 1, bytes.length)
+                    new byte[]{bytes.get()},
+                    result
                 );
             }
 

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutConstructorTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutConstructorTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2013 Netherlands Forensic Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package nl.minvenj.nfi.storm.kafka;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutFailurePolicyTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutFailurePolicyTest.java
@@ -30,16 +30,16 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 
-import nl.minvenj.nfi.storm.kafka.util.ConfigUtils;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.storm.spout.SpoutOutputCollector;
-import org.apache.storm.task.TopologyContext;
 import kafka.javaapi.consumer.ConsumerConnector;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.ReliableFailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.UnreliableFailHandler;
+import nl.minvenj.nfi.storm.kafka.util.ConfigUtils;
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 public class KafkaSpoutFailurePolicyTest {
@@ -49,6 +49,7 @@ public class KafkaSpoutFailurePolicyTest {
     public void setup() {
         _subject = new KafkaSpout();
     }
+
     @Test
     public void testCreateFailHandlerNull() {
         _subject.createFailHandler(null);

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutFailurePolicyTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/KafkaSpoutFailurePolicyTest.java
@@ -34,8 +34,8 @@ import nl.minvenj.nfi.storm.kafka.util.ConfigUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import kafka.javaapi.consumer.ConsumerConnector;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.ReliableFailHandler;

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/fail/ReliableFailHandlerTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/fail/ReliableFailHandlerTest.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/fail/ReliableFailHandlerTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/fail/ReliableFailHandlerTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Map;
 
-import org.junit.Test;
-
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
+import org.junit.Test;
+
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 /**

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/fail/UnreliableFailHandlerTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/fail/UnreliableFailHandlerTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Map;
 
-import org.junit.Test;
-
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
+import org.junit.Test;
+
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 public class UnreliableFailHandlerTest {

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/fail/UnreliableFailHandlerTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/fail/UnreliableFailHandlerTest.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import nl.minvenj.nfi.storm.kafka.util.KafkaMessageId;
 
 public class UnreliableFailHandlerTest {

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtilsTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtilsTest.java
@@ -16,6 +16,14 @@
 
 package nl.minvenj.nfi.storm.kafka.util;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.CONFIG_BUFFER_MAX_MESSAGES;
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.CONFIG_FILE;
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.CONFIG_GROUP;
@@ -32,23 +40,15 @@ import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.getMaxBufSize;
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.getStormZookeepers;
 import static nl.minvenj.nfi.storm.kafka.util.ConfigUtils.getTopic;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.storm.Config;
 import org.junit.Test;
 
-import org.apache.storm.Config;
 import nl.minvenj.nfi.storm.kafka.fail.AbstractFailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.ReliableFailHandler;

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtilsTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/util/ConfigUtilsTest.java
@@ -48,7 +48,7 @@ import java.util.Properties;
 
 import org.junit.Test;
 
-import backtype.storm.Config;
+import org.apache.storm.Config;
 import nl.minvenj.nfi.storm.kafka.fail.AbstractFailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.FailHandler;
 import nl.minvenj.nfi.storm.kafka.fail.ReliableFailHandler;

--- a/src/test/java/nl/minvenj/nfi/storm/kafka/util/KafkaMessageIdTest.java
+++ b/src/test/java/nl/minvenj/nfi/storm/kafka/util/KafkaMessageIdTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.number.OrderingComparison.comparesEqualTo;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 


### PR DESCRIPTION
- changes storm's groupId to `org.apache`
- `Scheme` now takes a `ByteBuffer` instead of a `byte[]`, use `wrap`
- storm 1.0.0 seems to be using `InetAddress.getLocalHost()` in a way that crashes openjdk on travis quite badly, remove openjdk from build matrix
